### PR TITLE
Downgraded PostgreSQL to 13.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - POSTGRES_USER
       - POSTGRES_HOST_AUTH_METHOD
     container_name: ads-postgres
-    image: postgres:14.2-alpine
+    image: postgres:13.5-alpine
     ports:
     - mode: ingress
       target: 5432


### PR DESCRIPTION
Downgraded PostgreSQL to 13.5 - latest version supported by Azure Flexible Server